### PR TITLE
remove verbose argument from `step_discretize_xgb()`

### DIFF
--- a/R/make_bins.R
+++ b/R/make_bins.R
@@ -172,7 +172,7 @@ if(any(bin_type %in% c("xgboost", "woe", "logreg"))){
     rec1 <- recipes::recipe(myform, data = .data)
 
     if(!use_cart){
-      rec2 <- embed::step_discretize_xgb(rec1, tidyselect::any_of(bin_cols_string), outcome = outcome1, num_breaks = n_bins, ..., verbose = 0)
+      rec2 <- embed::step_discretize_xgb(rec1, tidyselect::any_of(bin_cols_string), outcome = outcome1, num_breaks = n_bins, ...)
       abbv <- "xg"
     } else{
       rec2 <- embed::step_discretize_cart(rec1, tidyselect::any_of(bin_cols_string), outcome = outcome1, ...)


### PR DESCRIPTION
Hello @Harrison4192 👋 

I'm wrapping up a {recipes} release and this package popped up in the revdepcheck.

This version of {recipes} gives you better error messages when you missspell a argument name in a step. https://github.com/tidymodels/recipes/pull/1318. `num_comps` instead of `num_comp` in `step_pca()`. It caught a unused argument `verbose` this package used in `step_discretize_xgb()`.

https://github.com/tidymodels/recipes/pull/1318

I'm planning to sent in {recipes} by July 1st. If you are able to merge and send to CRAN beforehand that would be awesome, thank you!