### PR TITLE
Fix for purrr 1.2.0

### DIFF
--- a/R/make_bins.R
+++ b/R/make_bins.R
@@ -143,7 +143,7 @@ if(any(bin_type %in% c("xgboost", "woe", "logreg"))){
 
     .data %>%
       dplyr::summarize(dplyr::across(tidyselect::matches("\\.binned$"), dplyr::n_distinct)) %>%
-      purrr::map_chr(1) %>%
+      purrr::map_chr(function(x) as.character(x[[1]])) %>%
       stringr::str_c("_wo", .) -> bin_lens
 
 
@@ -224,5 +224,3 @@ if("logreg" %in% bin_type){
   .data %>% tibble::as_tibble()
 
 }
-
-

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -15,7 +15,7 @@ rename_bin_lens <- function(bin_df, abbv, cols){
 
   bin_df %>%
     dplyr::summarize(dplyr::across(.cols = cols, .fns =  ~dplyr::n_distinct(framecleaner::filter_missing(.)))) %>%
-    purrr::map_chr(1) %>%
+    purrr::map_chr(function(x) as.character(x[[1]])) %>%
     stringr::str_c("_", abbv, .) -> bin_lens
 
 
@@ -47,4 +47,3 @@ oner_wrapper <- function(bin_cols, .data, abbv, bin_method, n_bins = n_bins, pre
 
   .data %>% make_pretty(abbv = abbv, pretty_labels = pretty_labels)
 }
-


### PR DESCRIPTION
`map_chr()` no longer automatically coerces its output to a character vector since this was a common source of bugs. Apologies for failing to spot this in my pre-release checks.